### PR TITLE
新增开发前创意验证器用例

### DIFF
--- a/usecases/pre-build-idea-validator.md
+++ b/usecases/pre-build-idea-validator.md
@@ -1,6 +1,6 @@
 # 开发前创意验证器
 
-> 翻译自 [awesome-openclaw-usecases](https://github.com/hesamsheikh/awesome-openclaw-usecases)，含国内适配（百度指数 / 微信指数 / V2EX / 少数派）。
+> 含国内适配：百度指数 / 微信指数 / V2EX / 少数派
 
 在 OpenClaw 动手写代码之前，它会自动检查你的创意是否已经存在——扫描 GitHub、Hacker News、npm、PyPI 和 Product Hunt 五大数据源，根据竞争程度决定下一步行动。
 


### PR DESCRIPTION
## Summary

- 翻译并适配 pre-build-idea-validator 用例
- 基于 idea-reality-mcp MCP 服务器，在开发前扫描 GitHub/HN/npm/PyPI/Product Hunt 五大数据源，返回 0-100 竞争度评分
- 添加中国用户适配章节：
  - idea-reality-mcp v0.3.0 已支持中文输入（150+ 中英术语映射）
  - 补充国内市场验证平台（百度指数、微信指数、巨量算数、阿里指数等）
  - 补充国内社区替代（V2EX、少数派、掘金、Gitee 等）
  - 提供额外提示词覆盖国内市场调研
  - 列出适用场景（独立开发者、出海团队、黑客马拉松、产品经理）

## Test plan

- [ ] 验证 idea-reality-mcp 安装和配置步骤可复现
- [ ] 验证中文输入功能正常工作
- [ ] 确认国内平台链接有效
- [ ] 确认文件格式与仓库现有用例一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)