### PR TITLE
新增 3 个用例（播客/会议纪要/创意验证）并更新 README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Internal project docs (not for public)
 CLAUDE.md
 
+# Local workflow & process docs
+skills/
+
 # Research & handover docs
 awesome-openclaw-usecases-zh-项目交接报告.md
 Openclaw 落地用例研究.md

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 
 <h3>OpenClaw AI 智能体最佳真实用例大全</h3>
 
-<p>36 个经过验证的真实场景，手把手教你用 AI 智能体自动化工作与生活</p>
+<p>39 个经过验证的真实场景，手把手教你用 AI 智能体自动化工作与生活</p>
 
 <br/>
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![用例数量](https://img.shields.io/badge/用例-36-blue?style=flat-square)
+![用例数量](https://img.shields.io/badge/用例-39-blue?style=flat-square)
 ![中文](https://img.shields.io/badge/语言-简体中文-red?style=flat-square)
 ![新手友好](https://img.shields.io/badge/难度-新手友好-green?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)
@@ -152,6 +152,7 @@
 | [目标驱动的自主任务](usecases/overnight-mini-app-builder.md) | 告诉 AI 你的目标，它自动拆解并每天执行，还能一夜之间造出迷你应用 | ⭐⭐ |
 | [YouTube 内容流水线](usecases/youtube-content-pipeline.md) | 为 YouTube 频道自动化视频创意发掘、研究和追踪 | ⭐⭐⭐ |
 | [多智能体内容工厂](usecases/content-factory.md) | 在 Discord 中运行研究、写作、设计三个智能体组成的内容流水线 | ⭐⭐⭐ |
+| [播客制作流水线](usecases/podcast-production-pipeline.md) | 从选题到发布的全流程播客制作自动化（国内适配） | ⭐⭐ |
 
 ## 基础设施与 DevOps
 
@@ -183,6 +184,7 @@
 | [动态仪表板](usecases/dynamic-dashboard.md) | 实时仪表板，子智能体并行从 API、数据库和社交媒体获取数据 | ⭐⭐⭐ |
 | [自主项目管理](usecases/autonomous-project-management.md) | 使用 STATE.yaml 模式协调多智能体项目，无需人工编排 | ⭐⭐⭐ |
 | [多智能体专业团队](usecases/multi-agent-team.md) | 4 个专业 AI 智能体（战略+开发+营销+商务）作为你的虚拟团队 | ⭐⭐⭐ |
+| [会议纪要与待办自动化](usecases/meeting-notes-action-items.md) | 会议转录自动生成纪要并创建任务（国内适配） | ⭐⭐ |
 
 ## 研究与学习
 
@@ -194,6 +196,7 @@
 | [AI 财报追踪器](usecases/earnings-tracker.md) | 追踪科技/AI 公司财报，自动化预览、提醒和详细摘要 | ⭐⭐ |
 | [语义记忆搜索](usecases/semantic-memory-search.md) | 为 OpenClaw 记忆文件添加向量驱动的语义搜索 | ⭐⭐ |
 | [市场研究与产品工厂](usecases/market-research-product-factory.md) | 从 Reddit 和 X 挖掘真实痛点，让 AI 构建解决方案 MVP | ⭐⭐⭐ |
+| [开发前创意验证器](usecases/pre-build-idea-validator.md) | 编码前自动扫描竞品，返回竞争度评分（国内适配） | ⭐⭐ |
 
 ## 金融与交易
 

--- a/usecases/meeting-notes-action-items.md
+++ b/usecases/meeting-notes-action-items.md
@@ -1,0 +1,181 @@
+# 会议纪要与待办事项自动化
+
+> 含国内适配：飞书妙记 / 腾讯会议 / 钉钉
+
+刚开完一场 45 分钟的团队会议，你需要写会议纪要、提取行动项，然后分别录入 Jira、Linear 或待办清单——全靠手动。等你处理完，下一场会议已经开始了。如果在转录文本落地的那一刻，你的智能体就自动搞定这一切呢？
+
+这个用例把任何会议转录文本变成结构化纪要，并自动在项目管理工具中创建对应的任务。
+
+## 痛点
+
+会议纪要枯燥却重要。大多数人要么跳过不写（然后丢失上下文），要么花 20 多分钟手写。行动项经常被遗忘——因为它们只存在某人脑子里，或者埋在聊天记录的某个角落。这个智能体消除了"我们讨论过了"和"已记录、已分配"之间的断层。
+
+## 它能做什么
+
+| 功能 | 说明 |
+|------|------|
+| **监听转录来源** | 支持 Otter.ai 导出、Google Meet 转录、Zoom 录制摘要，或直接粘贴到对话中 |
+| **提取关键信息** | 识别决策事项、讨论话题、行动项及其负责人和截止日期 |
+| **自动创建任务** | 在 Jira、Linear、Todoist 或 Notion 中创建任务，分配给正确的人，附带会议上下文 |
+| **发布纪要摘要** | 将摘要推送到 Slack 或 Discord，让整个团队留存记录 |
+| **跟踪提醒** | 可选：在截止日期前通过定时提醒催办负责人 |
+
+## 所需技能
+
+- 项目管理平台集成：Jira、Linear、Todoist 或 Notion（用于任务创建）
+- 团队沟通工具集成：Slack 或 Discord（用于发布摘要）
+- 文件系统访问（用于读取转录文件）
+- 定时任务 / cron（用于跟踪提醒）
+- 可选：Otter.ai、Fireflies.ai 或 Google Meet API（用于自动获取转录文本）
+
+## 如何设置
+
+### 1. 选择转录来源
+
+最简单的方式是直接把转录文本粘贴到对话中。如果需要自动化，可以设置文件夹监控或 API 集成。
+
+### 2. 基础用法：粘贴转录并生成纪要
+
+```text
+I just finished a meeting. Here's the transcript:
+
+[paste transcript or point to file]
+
+Please:
+1. Write a concise summary (max 5 bullet points) covering key decisions and topics.
+2. Extract ALL action items. For each one, identify:
+   - What needs to be done
+   - Who is responsible (match names to my team)
+   - Deadline (if mentioned, otherwise mark as "TBD")
+3. Create a Jira ticket for each action item, assigned to the right person.
+4. Post the full summary to #meeting-notes in Slack.
+```
+
+### 3. 进阶：文件夹自动监控
+
+设置一个自动化管道，定期扫描转录文件并处理：
+
+```text
+Set up a recurring task: every 30 minutes, check ~/meeting-transcripts/ for
+new .txt or .vtt files. When you find one:
+
+1. Parse the transcript into a structured summary with action items.
+2. Create tasks in Linear for each action item.
+3. Post the summary to #team-updates in Slack.
+4. Move the processed file to ~/meeting-transcripts/processed/.
+
+For each action item with a deadline, set a reminder to ping the assignee
+in Slack one day before it's due.
+```
+
+### 4. 自定义输出格式
+
+```text
+When writing meeting summaries, always use this structure:
+- **Date & Attendees** at the top
+- **Key Decisions** — numbered list of what was decided
+- **Action Items** — table with columns: Task, Owner, Deadline, Status
+- **Open Questions** — anything unresolved that needs follow-up
+```
+
+## 关键洞察
+
+- 真正的价值不在于纪要本身，而在于**自动创建任务**。不转化为可追踪任务的会议纪要只是形式主义
+- 可以搭配 [Todoist 任务管理器](todoist-task-manager.md) 用例，获得对智能体创建的任务的完整可视化
+- Zoom 或 Google Meet 的 VTT/SRT 字幕文件是很好的输入——它们包含时间戳，帮助智能体将发言归属到具体的人
+- 先从最简单的开始（粘贴转录、获取摘要），验证输出质量后再逐步自动化。不要在验证效果之前就过度设计管道
+
+## 中国用户适配
+
+国内企业的会议场景和工具生态与海外有很大不同。以下是针对国内环境的适配方案。
+
+### 国内会议痛点
+
+据统计，国内企业因会议效率低下造成的损失平均占年度营收的 11%，其中会议纪要处理不当是主要诱因之一。常见痛点包括：
+
+- **会议太多**：员工被迫参加大量不必要的会议，纪要负担沉重
+- **纪要与执行脱节**：纪要写了没人看，行动项分散在聊天群里无人跟进
+- **转写工具碎片化**：飞书妙记、腾讯会议智能纪要、钉钉 AI 听记各有各的封闭生态，纪要数据难以跨平台流转
+
+### 转录来源替代方案
+
+| 原版工具 | 国内替代 | 说明 |
+|---------|---------|------|
+| Otter.ai / Fireflies.ai | **飞书妙记** | 支持 19 种语言，准确率 98%，可导出飞书文档/TXT/SRT 格式 |
+| Google Meet 转录 | **腾讯会议智能纪要** | 提供 REST API 获取转写段落和纪要摘要（需商业版/企业版） |
+| Zoom 录制摘要 | **钉钉 AI 听记** | 支持 72 种语言转写，可一键同步待办到钉钉待办 |
+| 直接粘贴 | **任何工具导出后粘贴** | 最通用的方式，不依赖特定平台 |
+
+### 任务创建替代方案
+
+| 原版工具 | 国内替代 | OpenClaw 技能 |
+|---------|---------|---------------|
+| Jira / Linear | **飞书项目（Meego）** | 通过 [feishu-doc](https://playbooks.com/skills/openclaw/openclaw/feishu-doc) 写入飞书文档，或使用飞书项目 API |
+| Todoist | **滴答清单** | [ticktick-api-skill](https://playbooks.com/skills/openclaw/skills/ticktick-api-skill) |
+| Notion | **飞书文档 / 钉钉文档** | [feishu-doc](https://playbooks.com/skills/openclaw/openclaw/feishu-doc) |
+| Slack / Discord | **飞书群聊 / 钉钉群聊** | 通过飞书/钉钉渠道插件直接发送 |
+
+### 飞书用户方案（推荐）
+
+飞书生态内可以实现最完整的闭环：会议录制 -> 妙记转写 -> OpenClaw 处理 -> 飞书文档 + 任务。
+
+**前置条件**：已完成 [飞书 AI 助手](cn-feishu-ai-assistant.md) 的基础接入。
+
+**安装飞书相关技能**：
+
+```bash
+npx playbooks add skill openclaw/openclaw --skill feishu-doc
+npx playbooks add skill openclaw/skills --skill feishu-calendar-tool
+```
+
+**使用方式**：会议结束后，从飞书妙记导出转写文本（TXT 或飞书文档格式），然后在飞书中发送给 OpenClaw 机器人：
+
+```text
+这是今天下午产品评审会的转录文本：
+[粘贴妙记导出的文本]
+
+请：
+1. 整理成结构化会议纪要（决策事项 + 行动项 + 待确认事项）
+2. 把纪要写入飞书文档，放到"会议纪要"文件夹
+3. 每个行动项标注负责人和截止日期
+4. 把纪要摘要发到产品组群聊
+```
+
+### 腾讯会议用户方案
+
+腾讯会议开放平台提供了录制转写 API（商业版/企业版），可通过 API 自动获取会议纪要：
+
+- 查询录制转写段落信息：`GET /v1/records/{record_file_id}/transcripts`
+- 查询智能纪要：`GET /v1/smart/minutes/{record_file_id}`
+
+获取到转写文本后，可通过 OpenClaw 进一步结构化处理并分发到对应的任务管理工具。
+
+### 钉钉用户方案
+
+钉钉 AI 听记支持将会议录音自动转写，并可一键同步待办到钉钉待办。2025 年底升级后支持图文纪要和 72 种语言。
+
+**前置条件**：已完成 [钉钉 AI 助手](cn-dingtalk-ai-assistant.md) 的基础接入。
+
+**使用方式**：会议结束后，从钉钉 AI 听记导出纪要文本，发送给 OpenClaw 钉钉机器人进行进一步处理和任务分发。
+
+### 实用建议
+
+- **先用最简单的方式验证**：不管用什么会议工具，先手动复制转写文本粘贴给 OpenClaw，确认输出质量满意后再考虑自动化
+- **飞书妙记 + OpenClaw 是目前最顺畅的组合**：飞书妙记导出格式规范，OpenClaw 飞书技能生态最成熟
+- **跨平台场景**：如果团队同时使用多个会议工具，统一导出为 TXT 后交给 OpenClaw 处理，用同一套模板输出
+- **安全提醒**：会议转录可能包含敏感商业信息，请确保 OpenClaw 运行在安全的环境中，不要将转录文本发送到不受信任的第三方服务
+
+> **安全提示**：腾讯会议 API 凭证和飞书应用密钥属于敏感信息，请通过环境变量或 `.env` 文件配置，确保 `.env` 已加入 `.gitignore`。
+
+## 相关链接
+
+- [Otter.ai](https://otter.ai/)
+- [Jira REST API](https://developer.atlassian.com/cloud/jira/platform/rest/v3/)
+- [Linear API](https://developers.linear.app/)
+- [Slack API](https://api.slack.com/)
+- [飞书妙记](https://www.feishu.cn/product/minutes) — 飞书官方会议转写工具
+- [腾讯会议开放平台](https://meeting.tencent.com/open-api.html) — 腾讯会议 API 文档
+- [钉钉 AI 听记](https://www.dingtalk.com/markets/dingtalk-ai) — 钉钉会议转写功能
+- [feishu-doc 技能 - ClawHub](https://playbooks.com/skills/openclaw/openclaw/feishu-doc)
+- [ticktick-api-skill 技能 - ClawHub](https://playbooks.com/skills/openclaw/skills/ticktick-api-skill)
+- [feishu-calendar-tool 技能 - ClawHub](https://playbooks.com/skills/openclaw/skills/feishu-calendar-tool)

--- a/usecases/podcast-production-pipeline.md
+++ b/usecases/podcast-production-pipeline.md
@@ -1,0 +1,167 @@
+# 播客制作流水线
+
+> 含国内适配：小宇宙 / 喜马拉雅 / B站 / 小红书宣发
+
+你有一堆播客选题，甚至已经列好了待录清单。但在嘉宾调研、大纲撰写、开场白起草、节目笔记整理、社交媒体宣发之间，制作开销消耗了你所有的创作热情。如果你只需要给出一个话题，就能拿回一整套可发布的制作包呢？
+
+这个用例把多个智能体串联起来，处理从选题到发布的完整播客制作流程。
+
+## 痛点
+
+独立播客主播和小团队在制作上花的时间远多于录制本身。嘉宾调研动辄数小时，节目笔记总是被拖延，社交媒体宣发更是第一个被砍掉的环节。真正有创造力的部分——对话本身——可能只占总工作量的 30%。这个智能体帮你处理剩下的 70%。
+
+## 它能做什么
+
+- **节目调研** — 给出话题或嘉宾名字，自动整理背景资料、谈话要点和建议问题
+- **大纲与脚本** — 生成结构化的节目大纲，包括开场白脚本、段落过渡和结束语
+- **节目笔记** — 录制完成后，将转录稿处理成带时间戳的节目笔记，附上提到的所有链接
+- **社交媒体素材包** — 为 X、LinkedIn 和 Instagram 生成包含节目亮点和金句的宣发帖文
+- **节目描述** — 撰写针对 Spotify、Apple Podcasts 和 YouTube 优化的 SEO 节目描述
+
+## 所需技能
+
+- 网络搜索 / 调研技能（用于嘉宾调研和话题深度研究）
+- 文件系统访问（用于读取转录稿和写入输出文件）
+- Slack、Discord 或 Telegram 集成（用于交付成品）
+- 可选：`sessions_spawn`（用于并行运行调研和写作智能体）
+- 可选：RSS feed 技能（用于监控竞品播客）
+
+## 如何设置
+
+1. 录制前——生成调研资料和节目大纲：
+
+```text
+I'm recording a podcast episode about [TOPIC]. My guest is [NAME].
+
+Please:
+1. Research the guest — their background, recent work, hot takes, and
+   anything controversial or interesting they've said publicly.
+2. Research the topic — key trends, recent news, common misconceptions,
+   and what the audience likely already knows vs. what would surprise them.
+3. Generate an episode outline:
+   - Cold open hook (1-2 sentences to grab attention)
+   - Intro script (30 seconds, casual tone)
+   - 5-7 interview questions, ordered from easy/rapport-building to deep/provocative
+   - 2-3 "back pocket" questions in case the conversation stalls
+   - Closing segment with call-to-action
+
+Save everything to ~/podcast/episodes/[episode-number]/prep/
+```
+
+2. 录制后——生成节目笔记和宣发素材：
+
+```text
+Here's the transcript for Episode [NUMBER]: [paste or point to file]
+
+Please:
+1. Write timestamped show notes — every major topic shift gets a timestamp
+   and one-line summary. Include links to anything mentioned (tools, books,
+   articles, people).
+2. Write an episode description (max 200 words) optimized for podcast
+   search. Include 3-5 relevant keywords naturally.
+3. Create social media posts:
+   - X/Twitter: 3 tweets — one pull quote, one key insight, one question
+     to spark discussion. Each under 280 chars.
+   - LinkedIn: 1 post, professional tone, 100-150 words.
+   - Instagram caption: 1 post with emoji, casual tone, include relevant hashtags.
+4. Extract a "highlights" list — the 3 most interesting/surprising moments
+   with timestamps.
+
+Save everything to ~/podcast/episodes/[episode-number]/publish/
+```
+
+3. 可选——竞品播客监控：
+
+```text
+Monitor these podcast RSS feeds daily:
+- [feed URL 1]
+- [feed URL 2]
+
+When a new episode drops that covers a topic relevant to my podcast,
+send me a Telegram message with:
+- Episode title and link
+- One-sentence summary
+- Whether this is something I should respond to or cover from my angle
+```
+
+## 关键洞察
+
+- **录制前调研**是最大的价值所在。带着深度嘉宾调研走进录音棚，对话质量会有质的飞跃——这不是后期能弥补的。
+- 带时间戳的**节目笔记**是提升听众留存的利器。大多数播客主播因为嫌麻烦而跳过这一步，但智能体让它变得毫不费力。
+- **社交媒体素材包**节省的是最多的*持续性*时间。每期都需要宣发，结构完全一样——这正是自动化的完美场景。
+- 与[多智能体内容工厂](content-factory.md)搭配使用效果更佳，可以将播客内容转化为博客文章、Newsletter 或视频片段。
+
+## 中国用户适配
+
+国内播客生态与海外有显著差异，以下是针对中国播客创作者的适配建议。
+
+### 平台替代方案
+
+| 海外平台 | 国内替代 | 说明 |
+|---------|---------|------|
+| Spotify for Podcasters | 小宇宙 | 国内最活跃的纯播客平台，支持 RSS 订阅和托管，有完善的创作者后台 |
+| Apple Podcasts | 喜马拉雅 | 用户体量最大的音频平台，需单独上传（不支持纯 RSS 导入） |
+| YouTube (播客视频化) | 网易云音乐播客 / B 站 | 网易云支持 RSS 导入；B 站适合视频播客 |
+| Anchor | 荔枝 FM / 蜻蜓 FM | 可作为补充分发渠道 |
+| Slack/Discord | 飞书 / 钉钉 / 微信 | 用于接收智能体交付的制作包 |
+
+### 分发策略
+
+国内播客分发分为两类：
+
+- **RSS 分发**（小宇宙、Apple Podcasts、网易云音乐等泛用型客户端）：生成一条 RSS 链接，提交到各平台即可自动同步
+- **手动上传**（喜马拉雅、荔枝 FM 等）：需要单独上传音频文件和节目信息，可以让智能体准备好各平台所需的元数据（标题、描述、标签），减少重复劳动
+
+建议使用 Firstory 等托管平台自动生成 RSS，再手动补充需要单独上传的平台。
+
+### 制作工具适配
+
+- **转录**：录制完成后可使用 [Whisper](https://github.com/openai/whisper) 进行本地转录，也可使用讯飞听见、飞书妙记等国内服务，中文识别准确率更高
+- **剪辑**：小宇宙提供「小宇宙 Studio」在线剪辑工具，与主播后台深度集成；也可使用 Adobe Audition、达芬奇等专业工具
+- **封面和视觉素材**：配合 AI 图像生成工具制作每期封面，保持品牌一致性
+
+### 社交媒体宣发适配
+
+录制后的宣发提示词建议替换为国内平台：
+
+```text
+Here's the transcript for Episode [NUMBER]: [paste or point to file]
+
+Please:
+1. Write timestamped show notes (same as original).
+2. Write an episode description (max 200 words) with 3-5 keywords,
+   optimized for 小宇宙 and 喜马拉雅 search.
+3. Create social media posts:
+   - 小红书: 1 post, conversational tone, include 5-8 hashtags,
+     highlight the most relatable listener moment.
+   - 微信公众号: 1 article draft, 800-1200 words, deeper recap
+     of episode themes with key quotes.
+   - 微博: 2 posts — one pull quote with guest photo prompt,
+     one question to spark discussion. Each under 140 chars.
+4. Extract a "highlights" list — the 3 most interesting moments
+   with timestamps, formatted for short video clips (抖音/视频号).
+
+Save everything to ~/podcast/episodes/[episode-number]/publish/
+```
+
+### 竞品监控适配
+
+将 RSS 监控目标替换为你关注的国内播客。小宇宙上的播客大多提供 RSS 链接，可以在节目页面找到。
+
+### 国内创作者特别提醒
+
+- **中文播客制作周期长**：据 CPA 中文播客社区统计，2024 年中文播客创作者平均每期净工作时长达 12.9 小时，其中剪辑平均耗时 4.5 小时。这意味着从调研、节目笔记到宣发的自动化可以显著降低非核心工作负担
+- **兼职创作者居多**：近八成播客从业者为兼职状态，制作时间碎片化。用智能体自动化流水线工作，可以把有限的时间集中在内容本身
+- **视频播客趋势**：2026 年视频播客正从"补充形态"变为"主流形态"。考虑在流水线中加入短视频切片（抖音/视频号）的自动化环节
+
+## 相关链接
+
+- [Podcast RSS Feed Spec (Apple)](https://podcasters.apple.com/support/823-podcast-requirements)
+- [Spotify for Podcasters](https://podcasters.spotify.com/)
+- [Whisper (OpenAI)](https://github.com/openai/whisper) — 本地转录生成
+- [小宇宙主播入驻](https://podcaster.xiaoyuzhoufm.com/)
+- [喜马拉雅创作中心](https://zhubo.ximalaya.com/)
+
+---
+
+**原文链接**：[English Version](https://github.com/hesamsheikh/awesome-openclaw-usecases/blob/main/usecases/podcast-production-pipeline.md)

--- a/usecases/pre-build-idea-validator.md
+++ b/usecases/pre-build-idea-validator.md
@@ -1,0 +1,158 @@
+# 开发前创意验证器
+
+> 含国内适配：百度指数 / 微信指数 / V2EX / 少数派
+
+在 OpenClaw 动手写代码之前，它会自动检查你的创意是否已经存在——扫描 GitHub、Hacker News、npm、PyPI 和 Product Hunt 五大数据源，根据竞争程度决定下一步行动。
+
+## 功能介绍
+
+- 在编写任何代码之前，自动扫描 5 个真实数据源（GitHub、Hacker News、npm、PyPI、Product Hunt）
+- 返回 `reality_signal` 竞争度评分（0-100），直观显示该领域的拥挤程度
+- 展示头部竞品及其 Star 数和描述
+- 当领域饱和时，自动建议差异化方向
+- 作为开发前的"关卡"：高分 = 停下来讨论，低分 = 直接开干
+
+## 痛点
+
+你告诉智能体"帮我做一个 AI 代码审查工具"，它高高兴兴地写了 6 个小时代码。然而 GitHub 上已有 143,000+ 个相关仓库——排名第一的有 53,000 颗 Star。智能体从不检查，因为你没让它查，它也不知道该查。你投入大量时间之后才发现竞争对手早已成熟。这个模式在每一个新项目中反复上演。
+
+## 所需技能
+
+- [idea-reality-mcp](https://github.com/mnemox-ai/idea-reality-mcp) — 扫描真实数据源并返回竞争度评分的 MCP 服务器
+
+## 如何设置
+
+1. 安装 idea-reality-mcp：
+
+```bash
+uvx idea-reality-mcp
+```
+
+2. 在 OpenClaw 配置中添加 MCP 服务器：
+
+```json
+{
+  "mcpServers": {
+    "idea-reality": {
+      "command": "uvx",
+      "args": ["idea-reality-mcp"]
+    }
+  }
+}
+```
+
+3. 将以下指令添加到你的 OpenClaw 智能体设置中：
+
+```text
+Before starting any new project, feature, or tool, always run idea_check first.
+
+Rules:
+- If reality_signal > 70: STOP. Report the top 3 competitors with star counts.
+  Ask me if I want to proceed, pivot, or abandon.
+- If reality_signal 30-70: Show me the results and pivot_hints.
+  Suggest a niche angle that existing projects don't cover.
+- If reality_signal < 30: Proceed to build.
+  Mention that the space is open.
+- Always show the reality_signal score and top competitors before writing any code.
+```
+
+## 真实案例
+
+**你：** "帮我做一个 AI 代码审查的 CLI 工具"
+
+OpenClaw 运行 `idea_check("AI code review tool")` 并回复：
+
+> **reality_signal: 90/100（非常高）**
+>
+> 头部竞品：
+> 1. Gitea — 53,940 stars
+> 2. reviewdog — 9,104 stars
+> 3. Danger (Ruby) — 5,649 stars
+>
+> 该领域有 143,000+ 个相关仓库，头部产品成熟且资金充裕。
+>
+> **差异化建议：**
+> - 聚焦特定语言（Rust/Go 专用 AI 代码审查）
+> - 针对特定框架（React/Vue 组件审查）
+> - 针对特定行业（金融/医疗代码合规审查）
+>
+> 要继续做差异化版本，还是换一个方向？
+
+**你：** "那做一个开发前创意验证的 MCP 服务器呢？"
+
+> **reality_signal: 8/100（非常低）**
+>
+> PyPI 和 npm 上没有直接竞品。GitHub 上有一些沾边的仓库，但没有一个解决完全相同的问题。
+>
+> 这个领域完全空白。开始开发。
+
+## 进阶玩法
+
+- **深度模式**：使用 `depth="deep"` 同时扫描全部 5 个数据源（GitHub + HN + npm + PyPI + Product Hunt），适合重大项目决策。
+- **批量验证**：在黑客马拉松前，给 OpenClaw 一份 10 个创意的清单，让它按 `reality_signal` 排名——分数最低的 = 最具原创性的机会。
+- **先试用 Web 版**：在 [mnemox.ai/check](https://mnemox.ai/check) 免费试用，看看这个工作流是否适合你的需求。
+
+## 关键洞察
+
+- 这能防止开发中最昂贵的错误：**解决一个已经被解决的问题**。
+- `reality_signal` 基于真实数据（仓库数量、Star 分布、HN 讨论量），而不是 LLM 猜测。
+- 高分不意味着"别做"——而是"要么差异化，要么别白费力气"。
+- 低分意味着真正的蓝海。这才是个人开发者胜算最大的方向。
+
+## 中国用户适配
+
+### idea-reality-mcp 已支持中文
+
+v0.3.0 版本新增了三阶段关键词提取管线，内置 150+ 中英术语映射（覆盖 15+ 领域），可以直接用中文描述你的创意。例如输入"宠物预约看诊 app"，会自动映射为"pet appointment veterinary booking app"进行搜索。
+
+### 数据源说明
+
+idea-reality-mcp 扫描的 5 个数据源（GitHub、Hacker News、npm、PyPI、Product Hunt）均为国际平台。对于面向国内市场的项目，建议补充以下国内数据源进行交叉验证：
+
+| 国际数据源 | 国内对应平台 | 用途 |
+|-----------|-------------|------|
+| Product Hunt | V2EX [创意] 板块、少数派 | 发现国内新产品和竞品 |
+| Hacker News | V2EX、掘金、CSDN | 技术社区讨论热度 |
+| GitHub | Gitee | 国内开源项目搜索 |
+| npm / PyPI | npm（通用）/ Gitee 镜像 | 包管理和依赖检索 |
+
+### 补充国内市场数据验证
+
+在 idea-reality-mcp 给出国际竞争度评分后，建议进一步通过国内数据平台验证市场需求：
+
+- **百度指数**（index.baidu.com）：查看关键词搜索趋势，判断用户是否在主动搜索你要解决的问题
+- **微信指数**：微信小程序内查看关键词在微信生态的热度，适合 C 端产品验证
+- **巨量算数**（trendinsight.oceanengine.com）：抖音/头条生态数据，了解短视频和内容领域的趋势
+- **阿里指数 / 生意参谋**：电商领域需求验证，查看商品搜索趋势和竞争程度
+- **36氪、IT桔子**：查看该领域是否已有融资项目，评估竞争格局
+
+### 建议补充的提示词
+
+在原版提示词基础上，可以添加以下规则以覆盖国内市场：
+
+```text
+After running idea_check, also help me research the Chinese market:
+- Search for similar products on V2EX, 少数派, and 36氪
+- Check Baidu Index trends for related keywords
+- Look for competing projects on Gitee
+- Summarize whether the idea has more or less competition in China vs. internationally
+```
+
+### 适用场景
+
+这个用例对国内开发者和创业者的价值尤其突出：
+
+- **独立开发者**：在 Product Hunt 或国内社区发布前，快速验证创意的全球竞争度
+- **出海团队**：验证产品在国际市场的竞争空间，找到差异化角度
+- **黑客马拉松参赛者**：批量筛选最具原创性的选题
+- **产品经理**：在立项前用数据说话，避免重复造轮子
+
+## 相关链接
+
+- [idea-reality-mcp GitHub](https://github.com/mnemox-ai/idea-reality-mcp)
+- [Web 在线体验](https://mnemox.ai/check)（无需安装即可试用）
+- [PyPI](https://pypi.org/project/idea-reality-mcp/)
+
+---
+
+**原文链接**：[English Version](https://github.com/AlexAnys/awesome-openclaw-usecases/blob/main/usecases/pre-build-idea-validator.md)


### PR DESCRIPTION
## Summary

- 新增播客制作流水线用例（国内适配：小宇宙/喜马拉雅/B站）
- 新增会议纪要与待办自动化用例（国内适配：飞书妙记/腾讯会议/钉钉）
- 新增开发前创意验证器用例（国内适配：百度指数/微信指数/V2EX）
- 更新 README 用例计数 36 → 39，添加 3 个目录条目
- 将 skills/ 目录加入 .gitignore（本地流程文档不上传）

合并时请使用 **Create a merge commit**（不要 squash）。