### PR TITLE
为第二大脑添加国内IM适配章节

### DIFF
--- a/usecases/second-brain.md
+++ b/usecases/second-brain.md
@@ -1,5 +1,7 @@
 # 第二大脑
 
+> 含国内适配：钉钉 / 飞书 / 企业微信
+
 你会产生想法、发现有趣的链接、听说要读的书——但你从来没有一个好的系统来捕获它们。Notion 变得复杂，Apple Notes 变成了一个拥有 10,000 条未读笔记的坟场。你需要的是像给朋友发短信一样简单的东西。
 
 这个工作流将 OpenClaw 变成一个通过短信交互的记忆捕获系统，背后有一个可随时浏览的自定义可搜索界面。
@@ -68,6 +70,58 @@ Include:
 
 - [OpenClaw 记忆系统](https://github.com/openclaw/openclaw)
 - [打造第二大脑（Tiago Forte）](https://www.buildingasecondbrain.com/)
+
+## 中国用户适配
+
+原用例使用 Telegram 作为消息捕获端，国内用户无法直接使用。以下是经过社区验证的国内 IM 替代方案。
+
+### 方案对比
+
+| 方案 | 门槛 | 公网 IP 需求 | OpenClaw 支持 | 推荐度 |
+|------|------|-------------|--------------|--------|
+| 钉钉 Stream | 最低 | 不需要 | 已验证 | 最高 |
+| 飞书 | 中等 | 需要（或长连接） | 已验证 | 高 |
+| 企业微信 | 中等 | 需要 | 已验证 | 高 |
+| 个人微信 | — | — | — | 不推荐 |
+
+### 钉钉 Stream 机器人（推荐首选）
+
+零公网 IP、零域名、零证书、零防火墙白名单——个人钉钉账号即可，完全免费。
+
+OpenClaw 生态已验证：`OpenClaw-Docker-CN-IM` 和 `openclaw-china` 均预装钉钉插件。
+
+**参考资源**：
+- GitHub: [ytanck/dingtalk-stream](https://github.com/ytanck/dingtalk-stream)
+- 阿里云百炼平台有"10 分钟搭建钉钉 AI 机器人"教程
+
+### 飞书机器人
+
+支持事件订阅（`im.message.receive_v1`），需在开发者后台创建企业自建应用。OpenClaw 集成成熟，阿里云有官方教程"OpenClaw + 飞书集成"。
+
+适合已使用飞书的团队。
+
+### 企业微信自建应用
+
+个人可注册（选"个人团队"类型），但未认证有功能限制。
+
+**参考资源**：
+- GitHub: [sunnoy/openclaw-plugin-wecom](https://github.com/sunnoy/openclaw-plugin-wecom)
+- GitHub: [dingxiang-me/OpenClaw-Wechat](https://github.com/dingxiang-me/OpenClaw-Wechat)
+
+### 一键部署方案
+
+如果不想逐个配置插件，可以使用社区整合的一键部署镜像：
+
+- [OpenClaw-Docker-CN-IM](https://github.com/justlovemaki/OpenClaw-Docker-CN-IM)：Docker 一键部署，预装飞书/钉钉/企微/QQ 插件
+- [openclaw-china](https://github.com/BytePioneer-AI/openclaw-china)：OpenClaw 中国插件集合
+
+### 关于个人微信
+
+**明确不推荐**。Hook 方案封号率极高（>80%），Wechaty iPad 协议存在法律风险。这是项目红线。
+
+如果你希望在微信生态内实现类似"第二大脑"功能，可以了解腾讯 IMA 知识库（非 OpenClaw 方案），它是微信生态内的零门槛知识管理产品，但不具备 OpenClaw 的智能体能力。
+
+> **安全提示**：使用社区 skill 和第三方插件时，请自行审查代码和权限范围。IM 机器人的 API 凭证属于敏感信息，请通过环境变量或 `.env` 文件配置，确保 `.env` 已加入 `.gitignore`。
 
 ---
 


### PR DESCRIPTION
在 second-brain.md 底部添加中国用户适配章节，推荐钉钉 Stream 模式作为 Telegram 的最佳替代方案。

## 变更内容

- 标题下方添加国内适配提示（钉钉 / 飞书 / 企业微信）
- 新增「中国用户适配」章节，包含：
  - 方案对比表（钉钉 Stream / 飞书 / 企业微信 / 个人微信）
  - 钉钉 Stream 机器人详细说明（推荐首选）
  - 飞书机器人接入说明
  - 企业微信自建应用说明
  - 一键部署方案（OpenClaw-Docker-CN-IM、openclaw-china）
  - 个人微信风险警告（项目红线）
  - 安全提示

## 原则

- 完整保留原有内容，未做任何修改
- 所有信息基于已验证的社区实践