### PR TITLE
更新 README：中国特色用例分类展示

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,41 +122,19 @@
 
 > 专为中国工具生态设计或适配的用例，使用飞书、钉钉、企业微信、小红书等国内平台。标注"适配"的用例在国际版基础上增加了国内方案。
 
-**IM 接入**
-
 | 名称 | 描述 | 难度 |
 |------|------|:---:|
 | [飞书 AI 助手](usecases/cn-feishu-ai-assistant.md) | 把 OpenClaw 部署为飞书机器人，在对话中直接触发 AI 任务，支持文档自动化 | ⭐⭐ |
 | [钉钉 AI 助手](usecases/cn-dingtalk-ai-assistant.md) | 把 OpenClaw 部署为钉钉机器人，Stream 模式无需公网 IP | ⭐⭐ |
 | [企业微信 AI 助手](usecases/cn-wecom-ai-assistant.md) | 在企业微信中使用 AI，通过微信插件让个人微信也能用 | ⭐⭐ |
-
-**生产力与办公**
-
-| 名称 | 描述 | 难度 |
-|------|------|:---:|
 | [早间简报（适配）](usecases/custom-morning-brief.md) | 每日定时推送简报到飞书/钉钉，支持中文新闻源和 cron 配置 | ⭐ |
 | [办公自动化套件](usecases/cn-office-automation.md) | 邮件管理、文件整理、会议纪要、周报生成，支持 163/QQ/Outlook | ⭐⭐ |
 | [会议纪要与待办自动化（适配）](usecases/meeting-notes-action-items.md) | 会议转录自动生成纪要并创建任务（飞书妙记/腾讯会议/钉钉） | ⭐⭐ |
 | [多渠道 AI 客户服务（适配）](usecases/multi-channel-customer-service.md) | 企业微信/抖音/小红书多渠道客服自动化 | ⭐⭐⭐ |
-
-**内容创作**
-
-| 名称 | 描述 | 难度 |
-|------|------|:---:|
 | [小红书内容自动化](usecases/cn-xiaohongshu-automation.md) | 从选题、文案、封面图到定时发布的全流程自动化 | ⭐ |
 | [播客制作流水线（适配）](usecases/podcast-production-pipeline.md) | 从选题到发布的全流程播客制作自动化（小宇宙/喜马拉雅/B站） | ⭐⭐ |
-
-**研究与金融**
-
-| 名称 | 描述 | 难度 |
-|------|------|:---:|
 | [AI 财报追踪器（适配）](usecases/earnings-tracker.md) | A 股财报追踪，AKShare 免费数据源 + 业绩预告/快报自动化 | ⭐⭐ |
 | [开发前创意验证器（适配）](usecases/pre-build-idea-validator.md) | 编码前自动扫描竞品（百度指数/微信指数/V2EX/少数派） | ⭐⭐ |
-
-**高级场景**
-
-| 名称 | 描述 | 难度 |
-|------|------|:---:|
 | [多智能体协作操作系统](usecases/cn-multi-agent-operating-system.md) | 把 OpenClaw 变成专业分工、协同、稳定迭代的智能体系统 | ⭐⭐⭐ |
 
 ---


### PR DESCRIPTION
## Summary

- 中国特色用例区扩充至 13 个，按场景分类展示（IM 接入 / 生产力与办公 / 内容创作 / 研究与金融 / 高级场景）
- 新增 AI 财报追踪器（适配）和多渠道 AI 客服（适配）到中国特色区
- 开发前创意验证器（适配）补充到中国特色区
- 下方分类区对应用例统一标注"（国内适配）"
- 新增 2026.3.4 更新公告

## 设计决策

- **适配用例同时出现在两处**：中国特色区作为精选导航，下方分类区保持完整目录便于按类浏览
- **中国特色区分类展示**：用例增多后按场景分组，避免一长串列表
- **"适配"标签**：中国特色区用"（适配）"简短标注，下方分类区用"（国内适配）"
