### PR TITLE
docs: 飞书用例更新 — 反映官方插件上线后的方案选择

### DIFF
--- a/usecases/cn-feishu-ai-assistant.md
+++ b/usecases/cn-feishu-ai-assistant.md
@@ -31,9 +31,14 @@
 | **安装复杂度** | 需额外安装 CLI 工具 + OAuth | 内置即用，`openclaw channels add` |
 | **维护方** | 飞书团队 | OpenClaw 社区 |
 
-**简单说**：主要用飞书做聊天入口 → 选内置插件（简单）；需要 AI 帮你操作文档、建表、约会议 → 选飞书官方插件（功能强）。两者不能同时启用。
+**简单说**：主要用飞书做聊天入口 → 选内置插件（简单）；需要 AI 帮你操作文档、建表、约会议 → 选飞书官方插件（功能强）。
 
-详细对比和迁移指南见 [openclaw-feishu 社区指南](https://github.com/AlexAnys/openclaw-feishu)。
+> ⚠️ **两种插件互斥，只能启用一个。** 安装飞书官方插件时会自动禁用内置插件。如果两个都装了，会出现 `duplicate plugin id` 报错导致飞书功能不可用。遇到这种情况，删除用户目录下的副本即可：
+> ```bash
+> rm -rf ~/.openclaw/extensions/feishu
+> openclaw gateway restart
+> ```
+> 详细对比和迁移指南见 [openclaw-feishu 社区指南](https://github.com/AlexAnys/openclaw-feishu)。
 
 ## 如何设置
 


### PR DESCRIPTION
## 改动说明

飞书官方插件（2026.3.6）上线后，用户现在有两种主流方式接入飞书。本 PR 在现有飞书用例基础上做增量更新：

### 具体改动
- **顶部**：新增 2026.3 更新提示，引导读者注意新选择
- **新增「选择建议」章节**：官方 vs 内置插件对比表 + 一句话选择建议
- **设置步骤**：标注适用于内置插件方案，补充官方插件安装入口
- **进阶章节**：标注官方插件用户无需额外安装文档技能
- **相关链接**：新增官方插件安装指南、飞书官方图文教程

### 不改动
- 现有设置步骤和实用建议保持不变
- 不涉及其他用例文件
- README 用例计数问题（39 vs 40）留到后续单独处理