### PR TITLE
feat: 新增 Agent Swarm 一人开发团队用例（国内适配）

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@
 | [AI 财报追踪器（适配）](usecases/earnings-tracker.md) | A 股财报追踪，AKShare 免费数据源 + 业绩预告/快报自动化 | ⭐⭐ |
 | [开发前创意验证器（适配）](usecases/pre-build-idea-validator.md) | 编码前自动扫描竞品（百度指数/微信指数/V2EX/少数派） | ⭐⭐ |
 | [多智能体协作操作系统](usecases/cn-multi-agent-operating-system.md) | 把 OpenClaw 变成专业分工、协同、稳定迭代的智能体系统 | ⭐⭐⭐ |
-| [Agent Swarm 一人开发团队（适配）](usecases/agent-swarm-dev-team.md) | OpenClaw 编排 Codex + Claude Code Agent 舰队，Git Worktree 隔离 + 三模型代码审查 + 自改进 Prompt | ⭐⭐⭐ |
+| [Agent Swarm 一人开发团队（适配）](usecases/agent-swarm-dev-team.md) | OpenClaw 编排 Codex + Claude Code 舰队，全自动化开发流水线 | ⭐⭐⭐ |
 
 ---
 

--- a/usecases/agent-swarm-dev-team.md
+++ b/usecases/agent-swarm-dev-team.md
@@ -1,6 +1,8 @@
 # Agent Swarm 一人开发团队（全配置指南）
 
 > 含国内适配：飞书/钉钉通知 / Codex 替代方案 / 国内监控平台
+>
+> **技术要求较高**：本用例涉及 Git Worktree、tmux、Cron、gh CLI 等系统级工具，建议有 Linux/macOS 命令行经验和 CI/CD 基础的用户使用。
 
 用 Codex 或 Claude Code 直接编码？它们只看到代码，看不到你的业务全貌。上下文窗口（context window）是零和博弈——填满代码就没有空间放业务上下文，填满客户历史就没有空间放代码。
 
@@ -153,6 +155,7 @@ Definition of Done（确保你的 Agent 知道这个）：
   "checks": {
     "prCreated": true,
     "ciPassed": true,
+    "codexReviewPassed": true,
     "claudeReviewPassed": true,
     "geminiReviewPassed": true
   },


### PR DESCRIPTION
## Summary

基于 [Elvis Sun 的 X 帖子](https://x.com/elvissun/status/2025920521871716562) 和 [知乎中文版](https://zhuanlan.zhihu.com/p/2010127051726792220)，新增 OpenClaw 编排 Codex + Claude Code Agent 舰队的完整用例。

- **新文件**: `usecases/agent-swarm-dev-team.md` — 含完整 8 步工作流、代码示例、中国用户适配
- **README 更新**: 添加到中国特色用例表和基础设施与 DevOps 表，用例计数 40→41

### 与现有用例的差异化

仓库已有 4 个多 Agent 用例（multi-agent-os、multi-agent-team、autonomous-pm、project-state-mgmt），本用例 6 项核心实现完全独创：

1. Git Worktree 隔离（每 Agent 独立分支和工作目录）
2. tmux 会话管理（支持中途纠偏）
3. 三模型代码审查（Codex + Gemini + Claude Code）
4. Ralph Loop V2 自改进 Prompt 系统
5. 端到端 8 步流水线（客户需求→PR 合并）
6. 异构模型调度（Codex 后端 / Claude Code 前端 / Gemini 设计）

### 国内适配内容

- 飞书/钉钉/企业微信通知替代 Telegram
- 阿里云 ARMS / 腾讯云监控替代 Sentry
- Codex 不可用时的 Claude Code 全替代方案
- 含飞书 Webhook 通知的完整提示词

## Test plan

- [ ] 验证 `usecases/agent-swarm-dev-team.md` 格式符合 CONTRIBUTING.md 模板
- [ ] 验证 README 中两处表格条目链接正确
- [ ] 验证用例计数徽章更新为 41
- [ ] 验证中国用户适配章节中的内部链接（飞书/钉钉/企业微信助手）指向正确文件
