### PR TITLE
feat: 新增微信公众号 Markdown 自动发布用例

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 <br/>
 <br/>
 
-<p><strong>46 个经过验证的真实场景，手把手教你用 AI 智能体自动化工作与生活</strong></p>
+<p><strong>47 个经过验证的真实场景，手把手教你用 AI 智能体自动化工作与生活</strong></p>
 
 <br/>
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![用例数量](https://img.shields.io/badge/用例-46-blue?style=flat-square)
+![用例数量](https://img.shields.io/badge/用例-47-blue?style=flat-square)
 ![中文](https://img.shields.io/badge/语言-简体中文-red?style=flat-square)
 ![新手友好](https://img.shields.io/badge/难度-新手友好-green?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)
@@ -138,6 +138,7 @@
 | [竞争对手分析与价格监控（适配）](usecases/competitive-intelligence.md) | Perplexity + Firecrawl MCP 竞品周报，百度指数/微信指数/飞书推送 | ⭐⭐ |
 | [HuggingFace 论文发现（适配）](usecases/hf-papers-research-discovery.md) | 每日热门 ML 论文筛选 + arXiv 深读，HF 镜像站/飞书推送 | ⭐ |
 | [arXiv 论文阅读与 LaTeX 写作（适配）](usecases/arxiv-paper-reader-latex-writer.md) | 论文获取/章节浏览/摘要速扫 + LaTeX 即时编译，中文模板/Docker 镜像适配 | ⭐⭐ |
+| [微信公众号 Markdown 自动发布](usecases/cn-wechat-official-publish.md) | 在飞书/Telegram 对话中一键发起公众号发布，扫码登录后继续 confirm 完成发布 | ⭐⭐ |
 
 ---
 
@@ -151,6 +152,7 @@
 | [每日 YouTube 摘要](usecases/daily-youtube-digest.md) | 获取你关注频道的每日新视频摘要，不错过任何内容 | ⭐ |
 | [X 账号分析](usecases/x-account-analysis.md) | 获取你的 X（原 Twitter）账号的定性分析 | ⭐⭐ |
 | [多源科技新闻摘要](usecases/multi-source-tech-news-digest.md) | 自动聚合 109+ 来源的科技新闻，支持质量评分和多渠道分发 | ⭐⭐ |
+| [微信公众号 Markdown 自动发布](usecases/cn-wechat-official-publish.md) | 把对话里的 Markdown 文章自动发布到微信公众号，支持二维码登录与状态追踪 | ⭐⭐ |
 
 ## 创意与构建
 

--- a/usecases/cn-wechat-official-publish.md
+++ b/usecases/cn-wechat-official-publish.md
@@ -1,0 +1,77 @@
+# 微信公众号 Markdown 自动发布
+
+写完一篇 Markdown 文章后，手动复制到公众号后台、反复调格式、再扫码登录发布，流程很长且容易中断。尤其在飞书/Telegram 里协作写作时，切来切去会明显降低效率。
+
+这个用例把 OpenClaw 作为发布入口：你在对话里说一句自然语言（如"帮我把这篇文章发到微信公众号上去"），智能体就会调用 `publish_wechat` Skill，把原始 Markdown 交给 Gateway 创建发布任务，并按状态引导你完成扫码登录与确认。
+
+## 它能做什么
+
+- **对话式发起发布**：在飞书/Telegram/Web 对话中直接触发公众号发布任务
+- **原始 Markdown 直传**：OpenClaw 不做 `markdown -> html` 转换，内容处理全部在 Gateway
+- **登录态闭环**：未登录时返回二维码图片，扫码后可继续 `confirm`
+- **状态可追踪**：随时查询任务状态，成功/失败都会返回 `task_id` 和 `status`
+- **错误可读**：对常见错误码（如 `409/422/502`）做友好提示，同时保留原始 `error.code`
+
+## 所需技能
+
+- 自定义 Skill：`publish_wechat`
+  - 支持命令：
+    - `/publish_wechat`
+    - `/publish_wechat status <task_id>`
+    - `/publish_wechat confirm <task_id>`
+    - `/publish_wechat relogin`
+- 后端服务：`openclaw-wechat-gateway`（负责与发布 Agent 交互）
+
+## 如何设置
+
+1. 部署并启动 Gateway 服务，确认可访问发布接口。
+2. 在 OpenClaw 安装 `publish_wechat` Skill（确保运行脚本可调用 Gateway）。
+3. 在对话里粘贴文章 Markdown，发送自然语言：
+
+```text
+帮我把这篇文章发到微信公众号上去
+```
+
+4. 如返回 `waiting_login`，OpenClaw 会发送二维码图片，使用微信扫码登录。
+5. 登录后发送：
+
+```text
+/publish_wechat confirm <task_id>
+```
+
+6. 需要查看进度时发送：
+
+```text
+/publish_wechat status <task_id>
+```
+
+7. 如登录态异常，可先重置登录态再重新发起发布：
+
+```text
+/publish_wechat relogin
+```
+
+## 可复制提示词
+
+```text
+把这篇文章发到微信公众号，标题就用第一行 H1，不要改正文内容。
+```
+
+```text
+登录成功了，继续发布刚才那个任务。
+```
+
+## 实用建议
+
+- **正文前先自检图片**：若文章里有外链图，先确认可公开访问，避免发布阶段触发图片策略失败。
+- **等待登录时不要重复发 publish**：先扫码，再 `confirm`，避免创建重复任务。
+- **给每篇文章唯一标题**：便于在状态查询和日志里快速定位任务。
+
+## 风控与合规提醒
+
+> ⚠️ 涉及公众号自动化时，请遵守微信公众平台规范与账号安全策略。建议先用测试号/低风险账号验证流程，再用于正式账号。不要批量高频发布，不要绕过平台风控机制。
+
+## 相关链接
+
+- [openclaw-wechat-gateway（实现仓库）](https://github.com/xu75/openclaw-wechat-gateway)
+- [OpenClaw 官方仓库](https://github.com/openclaw/openclaw)


### PR DESCRIPTION
## 变更内容
- 新增中文用例：`usecases/cn-wechat-official-publish.md`
- 在 README 的「中国特色用例」表格新增条目
- 在 README 的「社交媒体」表格新增条目
- 顶部用例数量由 42 更新为 43

## 用例说明
该用例描述了在飞书/Telegram 等对话渠道中，通过 `publish_wechat` Skill 将 Markdown 文章一键发起到微信公众号发布流程（含二维码登录、confirm、status、relogin）。

## 合规与风控
文档包含公众号自动化风控提醒，强调先用测试账号验证，再用于正式账号。