### PR TITLE
feat: 每日流量快照 GitHub Action

### DIFF
--- a/.github/workflows/traffic-snapshot.yml
+++ b/.github/workflows/traffic-snapshot.yml
@@ -1,0 +1,90 @@
+name: Traffic Snapshot
+
+on:
+  schedule:
+    - cron: '0 1 * * *'  # 每天 UTC 01:00（北京时间 09:00）
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch traffic data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          DATE=$(date -u +%Y-%m-%d)
+          mkdir -p stats
+
+          echo "## Snapshot $DATE" > stats/latest.md
+          echo "" >> stats/latest.md
+
+          # 基础指标
+          gh api "repos/$REPO" --jq '{stars: .stargazers_count, forks: .forks_count, watchers: .subscribers_count, open_issues: .open_issues_count}' > /tmp/basic.json
+          echo "### 基础指标" >> stats/latest.md
+          echo '```json' >> stats/latest.md
+          cat /tmp/basic.json >> stats/latest.md
+          echo '```' >> stats/latest.md
+          echo "" >> stats/latest.md
+
+          # 14 天 views（保留 count/uniques）
+          gh api "repos/$REPO/traffic/views" > /tmp/views.json || echo '{"error":"no-permission"}' > /tmp/views.json
+          echo "### Views（14 天）" >> stats/latest.md
+          echo '```json' >> stats/latest.md
+          jq '{count, uniques, days: (.views // [])}' /tmp/views.json >> stats/latest.md
+          echo '```' >> stats/latest.md
+          echo "" >> stats/latest.md
+
+          # 14 天 clones
+          gh api "repos/$REPO/traffic/clones" > /tmp/clones.json || echo '{"error":"no-permission"}' > /tmp/clones.json
+          echo "### Clones（14 天）" >> stats/latest.md
+          echo '```json' >> stats/latest.md
+          jq '{count, uniques}' /tmp/clones.json >> stats/latest.md
+          echo '```' >> stats/latest.md
+          echo "" >> stats/latest.md
+
+          # Top referrers
+          gh api "repos/$REPO/traffic/popular/referrers" > /tmp/refs.json || echo '[]' > /tmp/refs.json
+          echo "### Top Referrers（来源）" >> stats/latest.md
+          echo '```json' >> stats/latest.md
+          cat /tmp/refs.json >> stats/latest.md
+          echo '```' >> stats/latest.md
+          echo "" >> stats/latest.md
+
+          # Top paths（关键词流量核心——哪些用例被访问）
+          gh api "repos/$REPO/traffic/popular/paths" > /tmp/paths.json || echo '[]' > /tmp/paths.json
+          echo "### Top Paths（访问量 Top 10 页面）" >> stats/latest.md
+          echo '```json' >> stats/latest.md
+          cat /tmp/paths.json >> stats/latest.md
+          echo '```' >> stats/latest.md
+
+          # 追加到 JSONL 历史
+          DATE_ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          jq -n \
+            --arg date "$DATE_ISO" \
+            --slurpfile basic /tmp/basic.json \
+            --slurpfile views /tmp/views.json \
+            --slurpfile clones /tmp/clones.json \
+            --slurpfile refs /tmp/refs.json \
+            --slurpfile paths /tmp/paths.json \
+            '{date: $date, basic: $basic[0], views: $views[0], clones: $clones[0], referrers: $refs[0], paths: $paths[0]}' \
+            >> stats/history.jsonl
+
+      - name: Commit snapshot
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add stats/
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "stats: 每日流量快照 $(date -u +%Y-%m-%d)"
+            git push
+          fi

--- a/stats/README.md
+++ b/stats/README.md
@@ -1,0 +1,24 @@
+# 流量统计
+
+此目录由 `.github/workflows/traffic-snapshot.yml` 自动维护，每日北京时间 09:00 抓取。
+
+## 文件
+
+- `latest.md` — 最新一天的快照（人类可读）
+- `history.jsonl` — 历史快照流（每行一个 JSON，用于趋势分析）
+
+## 关键指标
+
+| 指标 | 来源 | 用途 |
+|------|------|------|
+| stars / forks / watchers | `/repos/:owner/:repo` | 健康度基线 |
+| views.count / uniques | `/traffic/views` | 14 天访问量（unique 更准） |
+| clones.count / uniques | `/traffic/clones` | 有多少人把仓库拉到本地 |
+| referrers | `/traffic/popular/referrers` | 外部站点引流来源 |
+| paths | `/traffic/popular/paths` | 具体哪些用例被访问——**关键词流量主信号** |
+
+## 用途
+
+- 对比做分发动作前后的 views/uniques 变化，判断渠道 ROI
+- 跟踪 paths 变化——当"claude-code 相关文件"开始出现在 top 10，说明跨 agent 定位生效
+- referrers 新出现的域名是发现新引流源的机会


### PR DESCRIPTION
## Summary
每天北京时间 09:00 自动抓取仓库 traffic 数据，写入 `stats/` 目录。

## 为什么
过去增长靠运气，没有数据支撑判断"哪个渠道/哪个关键词起作用"。这个 Action 提供：
- 每日 stars/forks/views/clones 基线
- Top Referrers 变化（新引流源预警）
- Top Paths（哪些用例被访问——跨 agent 定位生效信号）

## 输出
- `stats/latest.md` — 最新快照，人类可读
- `stats/history.jsonl` — 历史流，用于对比分析

## Test plan
- [ ] 手动触发一次 `workflow_dispatch` 验证能跑
- [ ] 确认 `stats/latest.md` 被创建并提交
- [ ] 第二天看是否自动更新