### PR TITLE
docs: 新增 Multica 多 CLI 协作看板用例（OpenClaw + Claude Code + Codex + Hermes）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <div align="center">
 
-<img width="1500" height="500" alt="OpenClaw AI 智能体最佳用例与案例合集 - 49 个真实场景" src="https://github.com/user-attachments/assets/4ae57dfb-4f18-4677-9136-43bf93017250" />
+<img width="1500" height="500" alt="OpenClaw AI 智能体最佳用例与案例合集 - 50 个真实场景" src="https://github.com/user-attachments/assets/4ae57dfb-4f18-4677-9136-43bf93017250" />
 
 <br/>
 <br/>
 
-<p><strong>49 个经过验证的真实场景，手把手教你用 AI 智能体自动化工作与生活</strong></p>
+<p><strong>50 个经过验证的真实场景，手把手教你用 AI 智能体自动化工作与生活</strong></p>
 
 <br/>
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![用例数量](https://img.shields.io/badge/用例-49-blue?style=flat-square)
+![用例数量](https://img.shields.io/badge/用例-50-blue?style=flat-square)
 ![中文](https://img.shields.io/badge/语言-简体中文-red?style=flat-square)
 ![新手友好](https://img.shields.io/badge/难度-新手友好-green?style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)
@@ -36,23 +36,23 @@
 
 </details>
 
-> **2026.4.20 更新**：新增中文互联网研究、微信公众号自动发布、数字人格蒸馏 3 个用例，中国特色用例扩充至 22 个。详见 [中国特色用例](#-中国特色用例)。
+> **2026.5.4 更新**：新增 Multica 多 CLI 协作看板用例——把 OpenClaw / Claude Code / Codex / Hermes 拉进同一个 Web 看板，Apache 2.0 自部署友好。详见 [基础设施与 DevOps](#基础设施与-devops)。
 
 ---
 
 ## 🗂 目录
 
 - [新手入门指南](#-新手入门指南)
-- **[🇨🇳 中国特色用例](#-中国特色用例)** — 22 个国内生态用例
+- **[🇨🇳 中国特色用例](#-中国特色用例)** — 23 个国内生态用例
   - [平台机器人](#平台机器人) (4) — 飞书、钉钉、企业微信等 IM 平台 AI 接入
   - [内容创作与发布](#内容创作与发布) (3) — 小红书、公众号、播客全流程自动化
   - [数据研究与监控](#数据研究与监控) (7) — A 股、财报、竞品、论文、中文互联网研究
   - [办公与客户服务](#办公与客户服务) (4) — 邮件、会议、多渠道客服、电商多 Agent
-  - [个人助理与智能体架构](#个人助理与智能体架构) (4) — 早间简报、人格档案、多 Agent 编排
+  - [个人助理与智能体架构](#个人助理与智能体架构) (5) — 早间简报、人格档案、多 Agent 编排
 - **[🌐 通用场景](#-通用场景)** — 国际用例合集（部分含国内适配）
   - [社交媒体](#社交媒体) (4) — Reddit、YouTube、X 等平台内容聚合
   - [创意与构建](#创意与构建) (3) — 内容创作流水线、从零构建产品
-  - [基础设施与 DevOps](#基础设施与-devops) (4) — 服务器自愈、工作流编排、可观测性
+  - [基础设施与 DevOps](#基础设施与-devops) (5) — 服务器自愈、工作流编排、可观测性、智能体看板
   - [生产力](#生产力) (16) — 邮件、日程、笔记、CRM、个人助理
   - [研究与学习](#研究与学习) (9) — 知识库、市场调研、论文发现、竞品分析
   - [金融与交易](#金融与交易) (1) — 预测市场模拟交易
@@ -123,7 +123,7 @@
 
 ## 🇨🇳 中国特色用例
 
-> 为中国工具生态设计或适配的用例，使用飞书、钉钉、企业微信、小红书等国内平台。标注"适配"的用例在国际版基础上增加了国内方案。共 22 个，按场景分 5 类。
+> 为中国工具生态设计或适配的用例，使用飞书、钉钉、企业微信、小红书等国内平台。标注"适配"的用例在国际版基础上增加了国内方案。共 23 个，按场景分 5 类。
 
 ### 平台机器人
 
@@ -181,6 +181,7 @@
 | [数字人格蒸馏（适配）](usecases/digital-persona-distillation.md) | 从 12+ 平台聊天记录提取 4 维人格档案，含飞书/微信采集和 PIPL 提醒 | ⭐⭐⭐ |
 | [多智能体协作操作系统](usecases/cn-multi-agent-operating-system.md) | 把 OpenClaw 变成专业分工、协同、稳定迭代的智能体系统 | ⭐⭐⭐ |
 | [Agent Swarm 一人开发团队（适配）](usecases/agent-swarm-dev-team.md) | OpenClaw 编排 Codex + Claude Code 舰队，全自动化开发流水线 | ⭐⭐⭐ |
+| [Multica 智能体看板（适配）](usecases/multica-managed-agents.md) | 把 OpenClaw / Claude Code / Codex / Hermes 拉进同一个 Web 看板，Issue 即任务、Apache 2.0 自部署 | ⭐⭐ |
 
 ---
 
@@ -219,6 +220,7 @@
 | [Opik 可观测性追踪](usecases/opik-openclaw-observability.md) | 将 OpenClaw 运行链路接入 Opik，统一查看 LLM/工具/子智能体追踪，并监控 token 与成本 | ⭐⭐ |
 | [自愈家庭服务器](usecases/self-healing-home-server.md) | 运行始终在线的基础设施智能体，自动发现并修复故障 | ⭐⭐⭐ |
 | [Agent Swarm 一人开发团队](usecases/agent-swarm-dev-team.md) | OpenClaw 编排 Codex + Claude Code 舰队实现全自动化开发流水线（国内适配） | ⭐⭐⭐ |
+| [Multica 智能体看板](usecases/multica-managed-agents.md) | 多 CLI 智能体统一 Web 看板，Issue 即任务、Skills 可复用，Apache 2.0 自部署（国内适配） | ⭐⭐ |
 
 ### 生产力
 

--- a/usecases/multica-managed-agents.md
+++ b/usecases/multica-managed-agents.md
@@ -129,7 +129,7 @@ multica daemon status --output json
 
 ### 4. 在 Web 看板创建 Agent
 
-打开 Web UI（云端 `https://multica.ai/app` 或自部署 `http://localhost:3002`），进入 **Settings → Agents → New Agent**：
+打开 Web UI（云端 `https://multica.ai/app` 或自部署 `http://localhost:3000`），进入 **Settings → Agents → New Agent**：
 
 | 字段 | 说明 |
 |------|------|
@@ -257,14 +257,15 @@ git clone https://github.com/multica-ai/multica.git
 cd multica && make selfhost-build
 ```
 
-自部署默认端口：前端 `http://localhost:3002`、后端 `http://localhost:8080`。`.env` 必填项：
+自部署默认端口：前端 `http://localhost:3000`、后端 `http://localhost:8080`（可用 `multica setup self-host --port 9090 --frontend-port 4000` 改）。`.env` 必填项：
 
 | 变量 | 说明 |
 |------|------|
 | `DATABASE_URL` | PostgreSQL 连接串 |
 | `JWT_SECRET` | 用 `openssl rand -hex 32` 生成 |
 | `FRONTEND_ORIGIN` | 前端 URL，用于 CORS |
-| `RESEND_API_KEY` | 邮件登录所需，国内可去 [Resend](https://resend.com) 注册（支持国内邮箱） |
+
+**邮件登录是可选的**——`RESEND_API_KEY` 留空时，验证码会打印到 daemon stdout（或 `~/.multica/daemon.log`），照抄即可登录；本地开发场景把 `APP_ENV=development` 打开还能用万能验证码 `888888`（**仅限本机/内网，不要在公网实例上用**）。需要正式邮件登录时再去 [Resend](https://resend.com) 注册并填 `RESEND_API_KEY` 与 `RESEND_FROM_EMAIL`。
 
 完整变量见 [SELF_HOSTING_ADVANCED.md](https://github.com/multica-ai/multica/blob/main/SELF_HOSTING_ADVANCED.md)。
 

--- a/usecases/multica-managed-agents.md
+++ b/usecases/multica-managed-agents.md
@@ -4,6 +4,16 @@
 
 把 OpenClaw、Claude Code、Codex、Hermes 同时用起来，最大的痛点不是工具不够强，而是**看不到全局**——每个 CLI 一个终端窗口，进度散落各处，分工和交接全靠脑子。Multica 把它们统一到一个 Web 看板上：每个 Agent 是看板上的"同事"，分配 Issue（任务条目）、提交评论、报告阻塞——和给真人分配任务一模一样。
 
+<p align="center">
+  <img src="https://raw.githubusercontent.com/multica-ai/multica/main/docs/assets/hero-screenshot.png" alt="Multica 看板视图：Backlog / Todo / In Progress / In Review / Done 五列，每张卡片显示 Issue 编号、标题、优先级和负责的 Agent" width="800">
+</p>
+
+### 一个 30 秒小例子
+
+周一早上你想推三件事：①调研最近两周新出的开源个人智能体；②修一个生产 bug；③给落地页换一版文案。以前要开三个终端、复制三段提示词、过半小时回头看哪个跑完了。
+
+在 Multica 里：在 Web 看板点 **New Issue** 三次写下三个标题 → 分别拖给 `OpenClaw (research)`、`Codex (backend)`、`Claude (frontend)` → 关上电脑去开会。每个 Agent 在你本机各自的工作目录里跑，状态从 `Backlog → In Progress → Done` 自动流转，完成后看板上能看到产物链接和评论，不用再切终端。
+
 ## 它能做什么
 
 - **自动发现 CLI** — Daemon（守护进程）启动时扫描 PATH，自动检测 `claude` / `codex` / `openclaw` / `hermes` / `gemini` / `opencode` / `pi` / `cursor-agent` / `kimi` / `kiro-cli`，注册为可选 Provider（智能体提供方）
@@ -26,6 +36,36 @@
 - 自部署可选：[Docker](https://www.docker.com/)（PostgreSQL 17 + pgvector）
 
 ## 如何设置
+
+### 0. 一句话让 Agent 替你装好
+
+如果手上已经有 OpenClaw 或 Hermes，把整个安装-配置-验证流程交给它一次跑完——**不要先 clone 仓库**，让 Agent 自己读官方 README 决定路径。把下面这段提示词贴给 OpenClaw / Hermes：
+
+以下提示词让 Agent 从零安装 Multica、根据你的需要选「云端」或「自部署」、启动 daemon 并验证已识别 PATH 上的 CLI：
+
+```text
+Set up Multica (https://github.com/multica-ai/multica) on this machine.
+
+1. Read the official README and CLI_AND_DAEMON.md to confirm the latest install path
+2. Ask me ONE question: "cloud (multica.ai)" or "self-host (Docker, no external deps)"?
+   - If I'm in mainland China or want zero external dependencies → recommend self-host
+   - If I want fastest path and don't mind email/OAuth login → recommend cloud
+3. Install via Homebrew if available, otherwise the official install script
+4. Run `multica setup cloud` OR `multica setup self-host` based on my answer
+5. Verify with `multica daemon status --output json` — confirm the agents array
+   includes every coding CLI installed on this machine (claude, codex, openclaw,
+   hermes, gemini, etc.)
+6. Print a 5-line summary: install method, daemon PID, detected providers,
+   workspace ID, next step ("open Web UI and create your first Agent")
+
+Do NOT hardcode any API keys. If a step needs credentials, pause and ask me.
+```
+
+跑完之后再回到下面的步骤 4 在 Web 看板上创建 Agent。如果你想完全跳过手动步骤，把 **本文件整段** 都喂给 Agent 也行——它会按 1-6 节顺序执行。
+
+> **两种部署怎么选**：
+> - **云端（multica.ai）** — 最快，邮件链接登录即用；依赖 Resend / Google OAuth，国内访问可能不稳
+> - **自部署** — Apache 2.0 协议本地起 Docker（前端 + Go 后端 + PostgreSQL 17 + pgvector），全程不出域，国内推荐
 
 ### 1. 安装 CLI
 

--- a/usecases/multica-managed-agents.md
+++ b/usecases/multica-managed-agents.md
@@ -1,0 +1,201 @@
+# Multica 多 CLI 协作看板（OpenClaw + Claude Code + Codex + Hermes）
+
+> 含国内适配：Apache 2.0 自部署 / 飞书机器人通知 / 国内 Provider（Kimi、Kiro）
+
+把 OpenClaw、Claude Code、Codex、Hermes 同时用起来，最大的痛点不是工具不够强，而是**看不到全局**——每个 CLI 一个终端窗口，进度散落各处，分工和交接全靠脑子。Multica 把它们统一到一个 Web 看板上：每个 Agent 是看板上的"同事"，分配 Issue（任务条目）、提交评论、报告阻塞——和给真人分配任务一模一样。
+
+## 它能做什么
+
+- **自动发现 CLI** — Daemon（守护进程）启动时扫描 PATH，自动检测 `claude` / `codex` / `openclaw` / `hermes` / `gemini` / `opencode` / `pi` / `cursor-agent` / `kimi` / `kiro-cli`，注册为可选 Provider（智能体提供方）
+- **Issue 即任务** — Web 看板创建 Issue → 指派 Agent → Agent 自动接手、执行、评论、改状态，与人类同事走同一条流水线
+- **Skills（技能）复用** — Agent 解决一次问题后，把方案沉淀为 Markdown 技能包，运行时自动注入到工作目录，跨 Agent / 跨任务复用
+- **Autopilot（自动驾驶）** — Cron（定时任务）或 Webhook（网络钩子）触发自动创建 Issue 并分配，三种并发策略：跳过 / 排队 / 替换
+- **本机 Runtime（运行时）** — Agent 在你自己的机器上执行（Daemon 每 3 秒拉任务、每 15 秒心跳），代码和密钥都不上传服务器
+- **多 Workspace（工作区）** — 不同项目独立隔离，Agent / Issue / Skill 互不干扰
+- **完全开源 + 自部署** — Apache 2.0 协议，Docker Compose 一键起本地服务，不依赖 multica.ai 云端
+
+## 所需技能
+
+- [Multica](https://github.com/multica-ai/multica) v0.2+（24k+ stars，Apache 2.0）
+- 至少一个编码 Agent CLI（任选一个或多个）：
+  - [OpenClaw](https://github.com/openclaw/openclaw)
+  - [Claude Code](https://docs.claude.com/claude-code)
+  - [Codex CLI](https://github.com/openai/codex)
+  - [Hermes](https://github.com/hermes-ai/hermes)
+  - 其他：`gemini` / `opencode` / `pi` / `cursor-agent` / `kimi` / `kiro-cli`
+- 自部署可选：[Docker](https://www.docker.com/)（PostgreSQL 17 + pgvector）
+
+## 如何设置
+
+### 1. 安装 CLI
+
+macOS / Linux 推荐 Homebrew：
+
+```bash
+# 一键安装 Multica CLI（自带 daemon）
+brew install multica-ai/tap/multica
+
+# 验证版本
+multica --version
+```
+
+Windows 用 PowerShell：`irm https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1 | iex`
+
+### 2. 一条命令完成配置
+
+云服务（multica.ai）：
+
+```bash
+# 配置 + 浏览器登录 + 启动 daemon，一气呵成
+multica setup cloud
+```
+
+自部署（不依赖国外服务）：
+
+```bash
+# 拉镜像 + 启动本地完整 server（前端 + 后端 + Postgres）
+curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh | bash -s -- --with-server
+multica setup self-host
+```
+
+### 3. 验证 daemon 已识别 CLI
+
+```bash
+multica daemon status --output json
+```
+
+预期 `agents` 字段列出所有 PATH 上检测到的 CLI，例如：
+
+```json
+{
+  "status": "running",
+  "agents": ["gemini", "claude", "codex", "openclaw", "hermes"],
+  "workspaces": [{"id": "..."}]
+}
+```
+
+如果某个 CLI 没出现，确认它已 `which <cli>` 可达，重启 daemon：`multica daemon restart`。
+
+### 4. 在 Web 看板创建 Agent
+
+打开 Web UI（云端 `https://multica.ai/app` 或自部署 `http://localhost:3002`），进入 **Settings → Agents → New Agent**：
+
+| 字段 | 说明 |
+|------|------|
+| Provider | 选 OpenClaw / Claude / Codex / Hermes 等 |
+| Runtime | 选你刚连接的本机 Runtime |
+| Name | 看板上的"工号"，如 `OpenClaw (research)`、`Codex (backend)`、`Claude (frontend)` |
+| Instructions | 可选系统提示词，定义 Agent 角色和边界 |
+| Max Concurrent Tasks | 并发上限，默认 6 |
+| Skills | 挂载已建好的技能文件 |
+| Env Vars | 注入 `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` 等密钥（**不要写进 Instructions**） |
+
+或用 CLI（先 `multica runtime list` 拿到 Runtime ID）：
+
+```bash
+multica agent create \
+  --name "OpenClaw (research)" \
+  --runtime-id "<your-runtime-id>" \
+  --visibility workspace
+```
+
+### 5. 创建 Issue 并分配
+
+```bash
+# CLI 创建 Issue
+multica issue create \
+  --title "调研个人 AI 智能体最新进展" \
+  --description "汇总最近两周开源的个人 Agent 项目，输出 Markdown 报告"
+
+# 列出 Issues 看状态变化
+multica issue list
+```
+
+Web UI 拖拽分配更直观。Agent 收到任务后状态变化：`queued → dispatched → running → completed/failed`，进度通过 WebSocket 实时回传到看板。
+
+### 6.（可选）让任务定时跑
+
+```bash
+# 创建 Autopilot：每天 9:00 自动创建一条 Issue 并分配
+multica autopilot create --help
+multica autopilot trigger-add --help
+```
+
+## 实用建议
+
+- **先跑通最小回路**：1 个 Agent + 1 条简单 Issue（"echo hello world"），确认 daemon 状态、Web UI 进度、`multica issue list` 三处一致后再扩展。日志默认在 `~/.multica/daemon.log`
+- **OpenClaw / Hermes 是一等公民**：从 v0.2 起在 Provider 下拉中直接选，无需手工注册插件
+- **`--model` 优先于 `--custom-args`**：OpenClaw 和 Codex app-server 在 `--custom-args` 里传 `--model` 会被拒绝，用顶层 `--model` 参数
+- **本机 Runtime 不出域**：Daemon 拉任务、写工作目录、调本地 CLI，源码和环境变量不离开你的设备。每个任务有独立工作目录 `~/multica_workspaces/<workspace-id>/<agent-id>/workdir`
+- **Skills 三种来源**：`multica skill import <url>` 从 clawhub.ai / skills.sh 一键导入；`multica skill create` + `multica skill files` 上传自己的 Markdown；Agent 完成任务后也可以让它自己沉淀技能
+- **Workspace 切环境**：不同项目用不同 Workspace（`MULTICA_WORKSPACE_ID` 环境变量切换），避免 Agent 上下文串味
+- **凭证只走 Agent Env Vars**：每个 Agent 单独配置环境变量，绝不硬编码到 Instructions 或代码
+
+## 相关链接
+
+- [Multica 官方仓库](https://github.com/multica-ai/multica) — 24k+ stars，Apache 2.0
+- [中文 README](https://github.com/multica-ai/multica/blob/main/README.zh-CN.md)
+- [CLI 与 Daemon 完整文档](https://github.com/multica-ai/multica/blob/main/CLI_AND_DAEMON.md)
+- [自部署进阶配置](https://github.com/multica-ai/multica/blob/main/SELF_HOSTING_ADVANCED.md)
+- [产品设计文档](https://github.com/multica-ai/multica/blob/main/docs/product-overview.md)
+- [OpenClaw 官方仓库](https://github.com/openclaw/openclaw)
+- [社区入门博客（OpenClaw API）](https://openclawapi.org/en/blog/2026-04-11-multica-ru-men)
+
+---
+
+## 中国用户适配
+
+### 优先选自部署
+
+`multica.ai` 云端依赖 Resend 邮件登录和 Google OAuth，国内访问不稳。**直接走自部署**——Apache 2.0 协议允许任意私有部署：
+
+```bash
+# 一键拉镜像 + 启动本地 server
+curl -fsSL https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh | bash -s -- --with-server
+multica setup self-host
+```
+
+如果 `ghcr.io` 拉镜像慢，从源码构建：
+
+```bash
+git clone https://github.com/multica-ai/multica.git
+cd multica && make selfhost-build
+```
+
+自部署默认端口：前端 `http://localhost:3002`、后端 `http://localhost:8080`。`.env` 必填项：
+
+| 变量 | 说明 |
+|------|------|
+| `DATABASE_URL` | PostgreSQL 连接串 |
+| `JWT_SECRET` | 用 `openssl rand -hex 32` 生成 |
+| `FRONTEND_ORIGIN` | 前端 URL，用于 CORS |
+| `RESEND_API_KEY` | 邮件登录所需，国内可去 [Resend](https://resend.com) 注册（支持国内邮箱） |
+
+完整变量见 [SELF_HOSTING_ADVANCED.md](https://github.com/multica-ai/multica/blob/main/SELF_HOSTING_ADVANCED.md)。
+
+### 飞书机器人通知
+
+Multica 没有内置飞书通知，让 Agent 在完成任务后调用飞书自定义机器人。把 `$FEISHU_WEBHOOK_URL` 通过 Agent **Env Vars** 注入，然后在 **Instructions** 加一段：
+
+以下提示词让 Agent 在任务进入终态时向飞书机器人推送一张交互卡片：
+
+```text
+## Notification on Task Completion
+
+When the assigned issue moves to a terminal state (completed/failed):
+1. POST a card message to $FEISHU_WEBHOOK_URL with msg_type "interactive"
+2. Card body should include: issue title, final status, branch/PR link if any,
+   ~80-char summary of what was done
+3. Skip notifications for intermediate states (queued/running/dispatched)
+4. On failure, append the last error line from the run log
+```
+
+飞书自定义机器人创建步骤参考 [飞书 AI 助手](cn-feishu-ai-assistant.md#创建自定义机器人)。
+
+### 国内 Provider 直连
+
+Multica Provider 列表已包含 `kimi`（Moonshot Kimi CLI）和 `kiro-cli`（Kiro），两者国内可直连。在 Web UI 创建 Agent 时直接选这两个 Provider，可避开海外 API 出口。
+
+---
+
+**实测参考**：daemon 在一台 Mac mini 上稳定运行约 11 天（`uptime 261h`），自动检测到 `gemini / claude / codex / openclaw / hermes` 五个 Provider；同 Workspace 内并行 Claude / Codex / Hermes 三个 Agent，三条 Issue 在 `in_review` 状态正常流转，Web 看板与 `multica issue list` 输出实时一致。

--- a/usecases/multica-managed-agents.md
+++ b/usecases/multica-managed-agents.md
@@ -12,12 +12,23 @@
 
 周一早上你想推三件事：①调研最近两周新出的开源个人智能体；②修一个生产 bug；③给落地页换一版文案。以前要开三个终端、复制三段提示词、过半小时回头看哪个跑完了。
 
-在 Multica 里：在 Web 看板点 **New Issue** 三次写下三个标题 → 分别拖给 `OpenClaw (research)`、`Codex (backend)`、`Claude (frontend)` → 关上电脑去开会。每个 Agent 在你本机各自的工作目录里跑，状态从 `Backlog → In Progress → Done` 自动流转，完成后看板上能看到产物链接和评论，不用再切终端。
+在 Multica 里：建一个 **Project（项目）**「Q2 上线冲刺」→ 三条 Issue 都挂在它下面 → 分别拖给 `OpenClaw (research)`、`Codex (backend)`、`Claude (frontend)` → 关上电脑去开会。每个 Agent 在你本机各自的工作目录里跑，状态从 `Backlog → In Progress → Done` 自动流转。
+
+**关键是它们能互相找到对方**：
+
+- **同一项目下 Issue 互相关联** — Codex 改 API 时把它的 Issue 设为 Claude 前端 Issue 的 **Parent（父任务）**，Claude 自动在评论里看到上游接口变更，不用你手动转告
+- **同一 Issue 多 Agent 接力** — Issue #12「修登录 bug」先指派给 OpenClaw 做根因分析，OpenClaw 在评论里 `@codex` 把修复任务交棒，Codex 拿到完整上下文（含 OpenClaw 写的诊断结论）继续编码，最后 `@claude` 跑 E2E 验证
+- **评论即协议** — Agent 之间通过 Issue 评论交换结论、链接、产物路径，所有交接对你完全透明，看板上一目了然
 
 ## 它能做什么
 
 - **自动发现 CLI** — Daemon（守护进程）启动时扫描 PATH，自动检测 `claude` / `codex` / `openclaw` / `hermes` / `gemini` / `opencode` / `pi` / `cursor-agent` / `kimi` / `kiro-cli`，注册为可选 Provider（智能体提供方）
 - **Issue 即任务** — Web 看板创建 Issue → 指派 Agent → Agent 自动接手、执行、评论、改状态，与人类同事走同一条流水线
+- **多 Agent 协作（核心）**：
+  - **Project（项目）汇聚** — 同一项目下所有 Issue 共享上下文，看板视图按列展示进度
+  - **Issue 父子关联** — 用 `--parent` 串成依赖链，子任务自动继承父任务的产物和决策
+  - **同一 Issue 多 Agent 接力** — 通过评论 `@agent-name` 把任务交棒下一位，下游 Agent 拿到完整对话历史和文件改动
+  - **评论即异步消息** — Agent 之间在 Issue 评论里交换结论、PR 链接、阻塞原因；人类随时插话纠偏
 - **Skills（技能）复用** — Agent 解决一次问题后，把方案沉淀为 Markdown 技能包，运行时自动注入到工作目录，跨 Agent / 跨任务复用
 - **Autopilot（自动驾驶）** — Cron（定时任务）或 Webhook（网络钩子）触发自动创建 Issue 并分配，三种并发策略：跳过 / 排队 / 替换
 - **本机 Runtime（运行时）** — Agent 在你自己的机器上执行（Daemon 每 3 秒拉任务、每 15 秒心跳），代码和密钥都不上传服务器
@@ -139,19 +150,61 @@ multica agent create \
   --visibility workspace
 ```
 
-### 5. 创建 Issue 并分配
+### 5. 创建 Issue 并分配（含多 Agent 协作）
+
+最简形式——单 Agent 一个 Issue：
 
 ```bash
-# CLI 创建 Issue
+# CLI 创建 Issue 并分配给一个 Agent
 multica issue create \
   --title "调研个人 AI 智能体最新进展" \
-  --description "汇总最近两周开源的个人 Agent 项目，输出 Markdown 报告"
+  --description "汇总最近两周开源的个人 Agent 项目，输出 Markdown 报告" \
+  --assignee "OpenClaw (research)"
 
-# 列出 Issues 看状态变化
-multica issue list
+multica issue list  # 看状态：queued → dispatched → running → completed/failed
 ```
 
-Web UI 拖拽分配更直观。Agent 收到任务后状态变化：`queued → dispatched → running → completed/failed`，进度通过 WebSocket 实时回传到看板。
+让多个 Agent 在同一项目下协作——**Project 汇聚 + 父子关联 + 评论交棒**：
+
+```bash
+# (1) 先建一个 Project 把所有相关 Issue 圈在一起
+multica project create --title "Q2 上线冲刺"
+PROJECT_ID="<上一步返回的 id>"
+
+# (2) 父任务：OpenClaw 做技术调研（产物会被下游引用）
+multica issue create \
+  --project "$PROJECT_ID" \
+  --title "调研 SSO 集成方案" \
+  --assignee "OpenClaw (research)"
+PARENT_ID="<上一步返回的 id>"
+
+# (3) 子任务：Codex 实现后端，依赖父任务的调研结论
+multica issue create \
+  --project "$PROJECT_ID" \
+  --parent "$PARENT_ID" \
+  --title "实现 SSO 后端 API" \
+  --assignee "Codex (backend)"
+
+# (4) 子任务：Claude 实现前端，并行进行
+multica issue create \
+  --project "$PROJECT_ID" \
+  --parent "$PARENT_ID" \
+  --title "实现 SSO 登录页 UI" \
+  --assignee "Claude (frontend)"
+```
+
+**同一 Issue 多 Agent 接力**——在评论里 `@另一个 Agent`，会自动把对话历史 + 文件改动作为上下文交棒下游：
+
+```bash
+# OpenClaw 完成根因分析后，把修复任务交棒给 Codex
+multica issue comment add <issue-id> \
+  --body "根因已定位在 src/auth/session.ts:42 的过期判断逻辑。@Codex 请按上述方案修复，记得补单测。"
+# Codex 完成后再交棒 Claude 跑 E2E
+multica issue comment add <issue-id> \
+  --body "已提交 PR #123，主要改动在 session.ts。@Claude 请在 staging 跑一遍登录 E2E。"
+```
+
+Web UI 拖拽分配更直观，Project 看板能一眼看清所有相关 Issue 的状态。Agent 收到任务后状态变化：`queued → dispatched → running → completed/failed`，进度通过 WebSocket 实时回传到看板。
 
 ### 6.（可选）让任务定时跑
 
@@ -164,6 +217,8 @@ multica autopilot trigger-add --help
 ## 实用建议
 
 - **先跑通最小回路**：1 个 Agent + 1 条简单 Issue（"echo hello world"），确认 daemon 状态、Web UI 进度、`multica issue list` 三处一致后再扩展。日志默认在 `~/.multica/daemon.log`
+- **多 Agent 协作的分工原则**：按"专长 + 上下文"分，不按"模型强弱"分。OpenClaw 适合领域调研和写文档（编排 + 业务上下文）、Codex 适合后端逻辑和复杂重构、Claude Code 适合前端和快速迭代、Hermes 适合长任务巡检。同一项目下让上游 Agent 把结论沉淀到 Issue 描述/评论，下游 Agent 通过 `--parent` 自动继承
+- **避免循环 @**：评论里 `@agent` 接力很好用，但要给最后一棒明确的"完成条件"（如"测试通过即关闭 Issue"），否则 Agent 之间可能互相 ping 来 ping 去消耗 token
 - **OpenClaw / Hermes 是一等公民**：从 v0.2 起在 Provider 下拉中直接选，无需手工注册插件
 - **`--model` 优先于 `--custom-args`**：OpenClaw 和 Codex app-server 在 `--custom-args` 里传 `--model` 会被拒绝，用顶层 `--model` 参数
 - **本机 Runtime 不出域**：Daemon 拉任务、写工作目录、调本地 CLI，源码和环境变量不离开你的设备。每个任务有独立工作目录 `~/multica_workspaces/<workspace-id>/<agent-id>/workdir`

--- a/usecases/multica-managed-agents.md
+++ b/usecases/multica-managed-agents.md
@@ -52,24 +52,21 @@
 
 如果手上已经有 OpenClaw 或 Hermes，把整个安装-配置-验证流程交给它一次跑完——**不要先 clone 仓库**，让 Agent 自己读官方 README 决定路径。把下面这段提示词贴给 OpenClaw / Hermes：
 
-以下提示词让 Agent 从零安装 Multica、根据你的需要选「云端」或「自部署」、启动 daemon 并验证已识别 PATH 上的 CLI：
-
 ```text
-Set up Multica (https://github.com/multica-ai/multica) on this machine.
+请帮我在这台机器上安装并初始化 Multica（https://github.com/multica-ai/multica）。
 
-1. Read the official README and CLI_AND_DAEMON.md to confirm the latest install path
-2. Ask me ONE question: "cloud (multica.ai)" or "self-host (Docker, no external deps)"?
-   - If I'm in mainland China or want zero external dependencies → recommend self-host
-   - If I want fastest path and don't mind email/OAuth login → recommend cloud
-3. Install via Homebrew if available, otherwise the official install script
-4. Run `multica setup cloud` OR `multica setup self-host` based on my answer
-5. Verify with `multica daemon status --output json` — confirm the agents array
-   includes every coding CLI installed on this machine (claude, codex, openclaw,
-   hermes, gemini, etc.)
-6. Print a 5-line summary: install method, daemon PID, detected providers,
-   workspace ID, next step ("open Web UI and create your first Agent")
+1. 先读官方 README 和 CLI_AND_DAEMON.md，确认最新的安装方式
+2. 问我一个问题，二选一：「云端 multica.ai」还是「自部署（Docker，不依赖任何外部服务）」？
+   - 我在中国大陆或者希望零外部依赖 → 推荐自部署
+   - 想最快上手、不介意邮件 / OAuth 登录 → 推荐云端
+3. 优先用 Homebrew 安装，没有 Homebrew 则用官方 install 脚本
+4. 根据我的选择执行 `multica setup cloud` 或 `multica setup self-host`
+5. 用 `multica daemon status --output json` 验证：确认 agents 数组里包含本机
+   PATH 上所有已安装的编码 CLI（claude / codex / openclaw / hermes / gemini 等）
+6. 最后用 5 行汇报结果：安装方式、daemon PID、识别到的 Provider 列表、
+   workspace ID、下一步操作（"打开 Web UI 创建第一个 Agent"）
 
-Do NOT hardcode any API keys. If a step needs credentials, pause and ask me.
+任何 API key 一律不要硬编码。需要凭证时先停下来问我。
 ```
 
 跑完之后再回到下面的步骤 4 在 Web 看板上创建 Agent。如果你想完全跳过手动步骤，把 **本文件整段** 都喂给 Agent 也行——它会按 1-6 节顺序执行。
@@ -273,17 +270,15 @@ cd multica && make selfhost-build
 
 Multica 没有内置飞书通知，让 Agent 在完成任务后调用飞书自定义机器人。把 `$FEISHU_WEBHOOK_URL` 通过 Agent **Env Vars** 注入，然后在 **Instructions** 加一段：
 
-以下提示词让 Agent 在任务进入终态时向飞书机器人推送一张交互卡片：
-
 ```text
-## Notification on Task Completion
+## 任务完成后推送飞书通知
 
-When the assigned issue moves to a terminal state (completed/failed):
-1. POST a card message to $FEISHU_WEBHOOK_URL with msg_type "interactive"
-2. Card body should include: issue title, final status, branch/PR link if any,
-   ~80-char summary of what was done
-3. Skip notifications for intermediate states (queued/running/dispatched)
-4. On failure, append the last error line from the run log
+当我分配的 Issue 进入终态（completed / failed）时，请：
+1. 向 $FEISHU_WEBHOOK_URL 发一张 msg_type 为 "interactive" 的飞书卡片消息
+2. 卡片正文需包含：Issue 标题、最终状态、分支或 PR 链接（如有）、
+   80 字以内的工作摘要
+3. 中间状态（queued / running / dispatched）不要发送通知
+4. 失败时，把运行日志的最后一行错误信息附在卡片末尾
 ```
 
 飞书自定义机器人创建步骤参考 [飞书 AI 助手](cn-feishu-ai-assistant.md#创建自定义机器人)。


### PR DESCRIPTION
## Summary

新增 `usecases/multica-managed-agents.md`（约 200 行），介绍开源的 Multica 多智能体管理平台——把 OpenClaw、Claude Code、Codex、Hermes 等 CLI 智能体拉进同一个 Web 看板，Issue 即任务、Skills 可复用、Apache 2.0 自部署。

- README 用例计数：49 → 50
- 中国特色用例：22 → 23
- 同时收录于「基础设施与 DevOps」和「个人助理与智能体架构」两个分类（前者标注「国内适配」，后者标注「适配」）

## 来源验证

| 来源 | 类型 |
|------|------|
| https://github.com/multica-ai/multica | 官方仓库（24k+ stars，Apache 2.0，2026-01 创建，持续维护） |
| https://github.com/multica-ai/multica/blob/main/docs/product-overview.md | 官方产品文档 |
| https://github.com/multica-ai/multica/blob/main/CLI_AND_DAEMON.md | 官方 CLI/Daemon 文档 |
| https://openclawapi.org/en/blog/2026-04-11-multica-ru-men | 社区入门博客（OpenClaw API） |
| 本机实测 | daemon 持续运行约 261h，自动检测到 5 个 Provider，3 个 Agent + 3 个 Issue 实际跑通 |

## 实测环境

- macOS（Mac mini）+ Multica v0.2.15（Homebrew）
- 自动检测：`gemini / claude / codex / openclaw / hermes`
- Workspace「Lab」内并行 Claude / Codex / Hermes 三个 Agent，3 条 Issue 在 `in_review` 状态正常流转

## Test plan

- [ ] 用例文件格式符合仓库模板（它能做什么 / 所需技能 / 如何设置 / 实用建议 / 相关链接）
- [ ] 技术术语首次出现时括号注释（Daemon、Runtime、Provider、Skills、Autopilot、Cron、Webhook 等）
- [ ] 凭证通过 Agent Env Vars 传递，无硬编码
- [ ] 代码块注释中文，命令保留英文
- [ ] 提示词保留英文原文，上方有中文说明
- [ ] README 徽章、计数、目录、两个分类表格均已更新
- [ ] 中国用户适配章节在文件底部，`---` 分隔线之后