### PR TITLE
fix(README): 修复失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,10 +321,10 @@
 
 ## 📈 Star History
 
-<a href="https://star-history.com/#AlexAnys/awesome-openclaw-usecases-zh&Date">
+<a href="https://star-history.dera.page/#AlexAnys/awesome-openclaw-usecases-zh&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=AlexAnys/awesome-openclaw-usecases-zh&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=AlexAnys/awesome-openclaw-usecases-zh&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=AlexAnys/awesome-openclaw-usecases-zh&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=AlexAnys/awesome-openclaw-usecases-zh&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=AlexAnys/awesome-openclaw-usecases-zh&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=AlexAnys/awesome-openclaw-usecases-zh&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
当前 README 中的 Star History 图表已失效，原因是 GitHub stargazer API 限制导致原有图表源无法正常工作。

本 PR 将图表切换至无需 API token 的替代数据源（star-history.dera.page），恢复仓库 Star 趋势展示，链接改为 hash 形式并保持原有参数不变。